### PR TITLE
Fix use-after-free

### DIFF
--- a/src/general.rs
+++ b/src/general.rs
@@ -11,7 +11,7 @@ pub fn dns_service_construct_fullname (service : &str,
         let unsafe_regtype = str_to_const_c (regtype);
         let unsafe_domain = str_to_const_c (domain);
 
-        match DNSServiceConstructFullName (buffer, unsafe_service, unsafe_regtype, unsafe_domain) {
+        match DNSServiceConstructFullName (buffer, unsafe_service.as_ptr(), unsafe_regtype.as_ptr(), unsafe_domain.as_ptr()) {
             0 => {
                 let fullname = mut_c_to_string (buffer);
                 free (buffer as *mut c_void);

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,6 @@
 use ffi::*;
 use txtrecord::TXTRecord;
-use utils::{option_str_to_const_c, str_to_const_c, if_no_error};
+use utils::{option_str_to_const_c, option_cstr_to_const_c, str_to_const_c, if_no_error};
 use callback::{SafeDomainEnumReply, SafeRegisterReply, SafeBrowseReply, SafeResolveReply,
     SafeRegisterRecordReply, SafeQueryRecordReply};
 use std::option::Option;
@@ -66,8 +66,15 @@ impl DNSService {
             let unsafe_host = option_str_to_const_c (host);
             let context = &callback_struct as *const _ as *mut c_void;
 
-            let result = DNSServiceRegister (&mut service.ptr, flags, interface_index, unsafe_name,
-                unsafe_regtype, unsafe_domain, unsafe_host, port, txt_record.get_length (),
+            let result = DNSServiceRegister (&mut service.ptr,
+                                             flags,
+                                             interface_index,
+                                             option_cstr_to_const_c(&unsafe_name),
+                                             unsafe_regtype.as_ptr(),
+                                             option_cstr_to_const_c(&unsafe_domain),
+                                             option_cstr_to_const_c(&unsafe_host),
+                                             port,
+                                             txt_record.get_length (),
                 &txt_record as *const _ as *const c_void, Some(SafeRegisterReply::<T>::wrapper), context);
 
             if_no_error (service, result)
@@ -85,8 +92,8 @@ impl DNSService {
             let unsafe_regtype = str_to_const_c (regtype);
             let unsafe_domain = str_to_const_c (domain);
             let context = &callback_struct as *const _ as *mut c_void;
-            let result = DNSServiceBrowse (&mut service.ptr, flags, interface_index, unsafe_regtype,
-                unsafe_domain, Some(SafeBrowseReply::<T>::wrapper), context);
+            let result = DNSServiceBrowse (&mut service.ptr, flags, interface_index, unsafe_regtype.as_ptr(),
+                unsafe_domain.as_ptr(), Some(SafeBrowseReply::<T>::wrapper), context);
 
             if_no_error (service, result)
         }
@@ -105,8 +112,8 @@ impl DNSService {
             let unsafe_regtype = str_to_const_c (regtype);
             let unsafe_domain = str_to_const_c (domain);
             let context = &callback_struct as *const _ as *mut c_void;
-            let result = DNSServiceResolve (&mut service.ptr, flags, interface_index, unsafe_name,
-                unsafe_regtype, unsafe_domain, Some(SafeResolveReply::<T>::wrapper), context);
+            let result = DNSServiceResolve (&mut service.ptr, flags, interface_index, unsafe_name.as_ptr(),
+                unsafe_regtype.as_ptr(), unsafe_domain.as_ptr(), Some(SafeResolveReply::<T>::wrapper), context);
 
             if_no_error (service, result)
         }
@@ -174,7 +181,7 @@ impl DNSService {
         let bytes = &data.into ();
         unsafe {
             let result = DNSServiceRegisterRecord (self.ptr, &mut record.ptr, flags, interface_index,
-                unsafe_fullname, rrtype, rrclass, bytes.len () as u16, bytes.as_ptr () as *const c_void,
+                unsafe_fullname.as_ptr(), rrtype, rrclass, bytes.len () as u16, bytes.as_ptr () as *const c_void,
                 ttl, Some(SafeRegisterRecordReply::<T>::wrapper), context);
 
             if_no_error (record, result)
@@ -192,7 +199,7 @@ impl DNSService {
         let context = &callback_struct as *const _ as *mut c_void;
         let unsafe_fullname = str_to_const_c (fullname);
         unsafe {
-            let result = DNSServiceQueryRecord (&mut service.ptr, flags, interface_index, unsafe_fullname,
+            let result = DNSServiceQueryRecord (&mut service.ptr, flags, interface_index, unsafe_fullname.as_ptr(),
                 rrtype, rrclass, Some(SafeQueryRecordReply::<T>::wrapper), context);
 
             if_no_error (service, result)
@@ -209,7 +216,7 @@ impl DNSService {
         let unsafe_fullname = str_to_const_c (fullname);
         let bytes = &data.into ();
         unsafe {
-            DNSServiceReconfirmRecord (flags, interface_index, unsafe_fullname, rrtype, rrclass,
+            DNSServiceReconfirmRecord (flags, interface_index, unsafe_fullname.as_ptr(), rrtype, rrclass,
                 bytes.len () as u16, bytes.as_ptr () as *const c_void)
         }
     }

--- a/src/txtrecord.rs
+++ b/src/txtrecord.rs
@@ -54,10 +54,10 @@ impl TXTRecord {
         unsafe {
             let new_key = str_to_const_c (key);
             match value_wrapper {
-                None => TXTRecordSetValue (&mut self.ptr, new_key, 0, null ()),
+                None => TXTRecordSetValue (&mut self.ptr, new_key.as_ptr(), 0, null ()),
                 Some (value) => {
                     let value_array = value.into ();
-                    TXTRecordSetValue (&mut self.ptr, new_key, value_array.len () as u8, value_array.as_ptr () as *const c_void)
+                    TXTRecordSetValue (&mut self.ptr, new_key.as_ptr(), value_array.len () as u8, value_array.as_ptr () as *const c_void)
                 },
             }
         }
@@ -65,7 +65,7 @@ impl TXTRecord {
 
     pub fn remove_value (&mut self,
                          key : &str) -> DNSServiceErrorType {
-        unsafe { TXTRecordRemoveValue (&mut self.ptr, str_to_const_c (key)) }
+        unsafe { TXTRecordRemoveValue (&mut self.ptr, str_to_const_c (key).as_ptr()) }
     }
 
     pub fn get_length (&self) -> u16 {
@@ -87,7 +87,7 @@ impl TXTRecord {
 impl TXTRecordData {
     pub fn contains_key (&self,
                          key : &str) -> bool {
-        let result = unsafe { TXTRecordContainsKey (self.len, self.ptr, str_to_const_c (key)) };
+        let result = unsafe { TXTRecordContainsKey (self.len, self.ptr, str_to_const_c (key).as_ptr()) };
         match result {
             1 => true,
             _ => false,
@@ -98,7 +98,7 @@ impl TXTRecordData {
                                   key : &'a str) ->  Option<TXTRecordItem<T>> {
         unsafe {
             let value_len : *mut uint8_t = uninitialized ();
-            let value = TXTRecordGetValuePtr (self.len, self.ptr, str_to_const_c (key), value_len);
+            let value = TXTRecordGetValuePtr (self.len, self.ptr, str_to_const_c (key).as_ptr(), value_len);
 
             if value == null () {
                 None

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,9 +7,9 @@ pub unsafe fn const_c_to_string (ptr : *const c_char) -> String {
     String::from_utf8 (CStr::from_ptr (ptr).to_bytes ().to_vec ()).unwrap ()
 }
 
-pub fn str_to_const_c (value : &str) -> *const c_char {
+pub fn str_to_const_c (value : &str) -> CString {
     let new_string = value.clone();
-    CString::new (new_string).unwrap ().as_ptr ()
+    CString::new (new_string).unwrap ()
 }
 
 pub unsafe fn mut_c_to_string (ptr : *mut c_char) -> String {
@@ -23,10 +23,17 @@ pub unsafe fn mut_c_to_string (ptr : *mut c_char) -> String {
     String::from_utf8 (result).unwrap ()
 }
 
-pub fn option_str_to_const_c (wrapper : Option<&str>) -> *const c_char {
+pub fn option_str_to_const_c (wrapper : Option<&str>) -> Option<CString> {
     match wrapper {
-        None => null (),
-        Some (value) => str_to_const_c (value),
+        None => None,
+        Some (value) => Some(str_to_const_c (value)),
+    }
+}
+
+pub fn option_cstr_to_const_c(wrapper : &Option<CString>) -> *const c_char {
+    match wrapper {
+        &None => null(),
+        &Some(ref value) => value.as_ref().as_ptr()
     }
 }
 


### PR DESCRIPTION
The CString was free'd at the end of the function so the pointer
we were returning pointed at the freed memory. This keeps
the CString alive long enough to be useful.